### PR TITLE
Add infrastructure to build Dockerfiles.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Process For Accepting Third Party Code Contributions
+
+To improve tracking of contributions to this project we will use a process
+modelled on the modified DCO 1.1 and use a "sign-off" procedure on patches that
+are being emailed around or contributed in any other way.
+
+The sign-off is a simple line at the end of the explanation for the patch,
+which certifies that you wrote it or otherwise have the right to pass it on as
+an open-source patch.  The rules are pretty simple: if you can certify the
+below:
+
+	Developer's Certificate of Origin 1.1
+
+	By making a contribution to this project, I certify that:
+
+	(a). The contribution was created in whole or in part by me and I
+	have the right to submit it under the open source license
+	indicated in the file; or
+
+	(b). The contribution is based upon previous work that, to the best
+	of my knowledge, is covered under an appropriate open source
+	License and I have the right under that license to submit that
+	work with modifications, whether created in whole or in part
+	by me, under the same open source license (unless I am
+	permitted to submit under a different license), as indicated
+	in the file; or
+
+	(c). The contribution was provided directly to me by some other
+	person who certified (a), (b) or (c) and I have not modified
+	it.
+
+	(d). The contribution is made free of any other party's intellectual
+	property claims or rights.
+
+	(e). I understand and agree that this project and the contribution
+	are public and that a record of the contribution (including all
+	personal information I submit with it, including my sign-off) is
+	maintained indefinitely and may be redistributed consistent with
+	project or the open source license(s) involved.
+
+then you just add a line saying
+
+	Signed-off-by: Random J Developer <random@developer.org>
+
+using your real name (sorry, no pseudonyms or anonymous contributions.)
+
+# Quick HOWTO
+
+1. Make sure you have a [GitHub account](https://github.com/signup/free)
+
+2. Fork the repo.
+
+3. Make sure you follow the [Best practices for writing Dockerfiles](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/)
+
+4. Push to your fork and submit a pull request.
+
+After 4. the pull request will be reviewed and checked.  We may suggest some
+changes or improvements or alternatives.

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,159 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Apache License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Version 2.0, January 2004
 
-   1. Definitions.
+http://www.apache.org/licenses/
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+1. Definitions.
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source, and
+configuration files.
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object
+code, generated documentation, and conversions to other media types.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that is
+included in or attached to the work (an example is provided in the Appendix
+below).
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the purposes
+of this definition, "submitted" means any form of electronic, verbal, or
+written communication sent to the Licensor or its representatives, including
+but not limited to communication on electronic mailing lists, source code
+control systems, and issue tracking systems that are managed by, or on behalf
+of, the Licensor for the purpose of discussing and improving the Work, but
+excluding communication that is conspicuously marked or otherwise designated in
+writing by the copyright owner as "Not a Contribution."
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+2. Grant of Copyright License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable copyright license to
+reproduce, prepare Derivative Works of, publicly display, publicly perform,
+sublicense, and distribute the Work and such Derivative Works in Source or
+Object form.
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+3. Grant of Patent License. Subject to the terms and conditions of this
+License, each Contributor hereby grants to You a perpetual, worldwide,
+non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this
+section) patent license to make, have made, use, offer to sell, sell, import,
+and otherwise transfer the Work, where such license applies only to those
+patent claims licensable by such Contributor that are necessarily infringed by
+their Contribution(s) alone or by combination of their Contribution(s) with the
+Work to which such Contribution(s) was submitted. If You institute patent
+litigation against any entity (including a cross-claim or counterclaim in a
+lawsuit) alleging that the Work or a Contribution incorporated within the Work
+constitutes direct or contributory patent infringement, then any patent
+licenses granted to You under this License for that Work shall terminate as of
+the date such litigation is filed.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+4. Redistribution. You may reproduce and distribute copies of the Work or
+Derivative Works thereof in any medium, with or without modifications, and in
+Source or Object form, provided that You meet the following conditions:
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+    You must give any other recipients of the Work or Derivative Works a copy
+of this License; and
+    You must cause any modified files to carry prominent notices stating that
+You changed the files; and
+    You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from the
+Source form of the Work, excluding those notices that do not pertain to any
+part of the Derivative Works; and
+    If the Work includes a "NOTICE" text file as part of its distribution, then
+any Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents
+of the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+    You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such Derivative
+Works as a whole, provided Your use, reproduction, and distribution of the Work
+otherwise complies with the conditions stated in this License.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any
+Contribution intentionally submitted for inclusion in the Work by You to the
+Licensor shall be under the terms and conditions of this License, without any
+additional terms or conditions. Notwithstanding the above, nothing herein shall
+supersede or modify the terms of any separate license agreement you may have
+executed with Licensor regarding such Contributions.
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+6. Trademarks. This License does not grant permission to use the trade names,
+trademarks, service marks, or product names of the Licensor, except as required
+for reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in
+writing, Licensor provides the Work (and each Contributor provides its
+Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied, including, without limitation, any warranties
+or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+PARTICULAR PURPOSE. You are solely responsible for determining the
+appropriateness of using or redistributing the Work and assume any risks
+associated with Your exercise of permissions under this License.
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+8. Limitation of Liability. In no event and under no legal theory, whether in
+tort (including negligence), contract, or otherwise, unless required by
+applicable law (such as deliberate and grossly negligent acts) or agreed to in
+writing, shall any Contributor be liable to You for damages, including any
+direct, indirect, special, incidental, or consequential damages of any
+character arising as a result of this License or out of the use or inability to
+use the Work (including but not limited to damages for loss of goodwill, work
+stoppage, computer failure or malfunction, or any and all other commercial
+damages or losses), even if such Contributor has been advised of the
+possibility of such damages.
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+9. Accepting Warranty or Additional Liability. While redistributing the Work or
+Derivative Works thereof, You may choose to offer, and charge a fee for,
+acceptance of support, warranty, indemnity, or other liability obligations
+and/or rights consistent with this License. However, in accepting such
+obligations, You may act only on Your own behalf and on Your sole
+responsibility, not on behalf of any other Contributor, and only if You agree
+to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
 
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "{}"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright {yyyy} {name of copyright owner}
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+END OF TERMS AND CONDITIONS

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SHELL := /bin/bash
+
+# Docker command must be installed
+DOCKER_TOOL := $(shell command -v docker)
+ifeq ($(DOCKER_TOOL),)
+    $(error Unable to find docker command at PATH)
+endif
+
+# lsb_release must be installed
+LSB_TOOL := $(shell command -v lsb_release)
+ifeq ($(LSB_TOOL),)
+    $(error Unable to find lsb_release command at PATH)
+endif
+
+CONFIG_ROOT := $(shell pwd)/configs
+
+ifndef AT_CONFIGSET
+    AT_CONFIGSET := $(shell basename $$(ls -d $(CONFIG_ROOT)/[1-9]*.[0-9] | tail -1))
+    ifeq ($(AT_CONFIGSET),)
+        $(error Couldn't infer AT_CONFIGSET variable, and no hint was given... Bailing out!)
+    else
+        $(warning AT_CONFIGSET variable not informed... Using latest one ($(AT_CONFIGSET)).)
+    endif
+endif
+
+CONFIG := $(CONFIG_ROOT)/$(AT_CONFIGSET)
+HOST_ARCH := $(shell uname -m)
+DISTRO_NAME := $(shell $(LSB_TOOL) -i -s | tr [:upper:] [:lower:])
+
+ifeq ($(HOST_ARCH),ppc64le)
+    BUILD_ARCH := $(HOST_ARCH)
+else ifeq ($(HOST_ARCH),x86_64)
+# Image for cross compiler
+    BUILD_ARCH := x86_64.ppc64le
+else
+    $(error Unsupported host architecture ($(HOST_ARCH)) to build the image)
+endif
+
+ifndef IMAGE_PROFILE
+    IMAGE_PROFILE := devel
+endif
+
+DOCKER_FILE := $(CONFIG)/$(DISTRO_NAME)/Dockerfile-$(IMAGE_PROFILE)_$(BUILD_ARCH)
+
+IMAGE_TAG := at/$(AT_CONFIGSET):$(DISTRO_NAME)_$(IMAGE_PROFILE)_$(BUILD_ARCH)
+
+.PHONY: all clean
+
+all: $(DOCKER_FILE)
+	@echo Build docker image with $(IMAGE_TAG) tag
+	$(DOCKER_TOOL) build -t $(IMAGE_TAG) -f $(DOCKER_FILE) $(CONFIG)
+clean:
+	@echo Remove docker image tagged $(IMAGE_TAG)
+	$(DOCKER_TOOL) rmi $(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,42 @@
-# at-docker
-Holds dockerfiles and build script to create Docker images of the Advanced Toolchain
+# About
+
+The Dockerfiles distributed alongside this readme will produce Docker images that contain Advance Toolchain stack. Each image is composed of a bare minimum Linux distribution on which the Advance Toolchain is supported, and some extra development tools for C and C++. The Advance Toolchain provides a set of packages that will be installed according to the following profiles:
+
+  - Runtime: the image comes with only runtime and mcore-libs (Multi-core libraries) packages, resulting in a image with smaller size.
+  - Development: the image comes with development, performance, and runtime packages.
+
+# Requirements
+If you are going to use the Makefile for builds, then the following commands should be installed in your host machine:
+
+ - make
+ - lsb\_release
+ - docker
+
+Notice that the Linux user used to build Docker images should have permission to run the **docker** command. Check your Linux distribution documentation for more information on this topic.
+
+# Build
+The *configs* directory contain a set of Dockerfiles to build images with different combinations of AT version (and packages), and a base Linux distribution. Thus, to ease the build process, use the **make** command as follows:
+
+```
+$ make
+```
+
+By default **make** builds an image with following configuration:
+
+ - Latest AT version
+ - Base image OS same of the host
+ - Development profile
+
+Some build parameters are available though, use following environment variables to set them:
+
+ - **AT\_CONFIGSET**=*version*, where *version* is the AT version (9.0, 10.0, and so on)
+ - **IMAGE\_PROFILE**=*profile*, where *profile* indicates a profile which may be either *runtime* or *devel*
+
+The Makefile get the name of your host's OS to select a suitable image OS. Thus, you must use a Linux distribution to build the image on which we provide a Dockerfile for the same OS. You can check supported distribution in the directory configs/*version*/ for the given Advance Toolchain *version*.
+
+# Run
+You can use **docker run** to create a container from AT images. For example, following command starts a container from AT 10.0 devel image and attach to a shell session:
+```
+docker run -it --privileged at/10.0:ubuntu_devel_ppc64le 
+```
+**Important**: some commands as gdb and ocount require access to host devices which are usually denied by default. This can be circumveted by granting privileged access to the container (see --privileged flag in above example), or allowing access to specfic devices. See [Runtime privilege and Linux capabilities](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities) section at Docker Engine Reference for further details.

--- a/configs/10.0/ubuntu/Dockerfile-devel_ppc64le
+++ b/configs/10.0/ubuntu/Dockerfile-devel_ppc64le
@@ -1,0 +1,40 @@
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ppc64le/ubuntu:14.04
+
+WORKDIR /root
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Configure apt to nicely install packages
+RUN apt-get update \
+    && apt-get install -y apt-utils \
+    && apt-get install -y autoconf automake bison byacc ccache cscope ctags curl flex \
+        elfutils libtool libstdc++-4.8-dev m4 make man-db \
+    && apt-get clean
+
+ENV AT_VERSION 10.0
+
+RUN curl -O ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key \
+    && apt-key add 6976a827.gpg.key \
+    && rm -f 6976a827.gpg.key \
+    && echo "deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu trusty at${AT_VERSION}" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y advance-toolchain-at${AT_VERSION}-runtime advance-toolchain-at${AT_VERSION}-devel \
+        advance-toolchain-at${AT_VERSION}-perf advance-toolchain-at${AT_VERSION}-mcore-libs
+
+ENV PATH /opt/at${AT_VERSION}/bin:$PATH
+
+CMD ["/bin/bash"]

--- a/configs/10.0/ubuntu/Dockerfile-runtime_ppc64le
+++ b/configs/10.0/ubuntu/Dockerfile-runtime_ppc64le
@@ -1,0 +1,35 @@
+# Copyright 2017 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM ppc64le/ubuntu:14.04
+
+WORKDIR /root
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV AT_VERSION 10.0
+
+RUN apt-get update \
+    && apt-get install -y apt-utils \
+    && apt-get install -y wget man-db \
+    && wget ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key \
+    && apt-key add 6976a827.gpg.key \
+    && rm -f 6976a827.gpg.key \
+    && echo "deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu trusty at${AT_VERSION}" >> /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y advance-toolchain-at${AT_VERSION}-runtime advance-toolchain-at${AT_VERSION}-mcore-libs
+
+ENV PATH /opt/at${AT_VERSION}/bin:$PATH
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This adds a Makefile-based infrastructure to build
Docker images containing AT. It is added Dockerfiles
that create Ubuntu 14.04 (ppc64le) images of AT 10.0.

Also added readme, license and contributing files.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@linux.vnet.ibm.com>