### PR TITLE
Enhace docker images to work on multiple AT / distro versions

### DIFF
--- a/configs/10.0/ubuntu/Dockerfile-devel_ppc64le
+++ b/configs/10.0/ubuntu/Dockerfile-devel_ppc64le
@@ -12,25 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ppc64le/ubuntu:14.04
+ARG UBUNTU_RELEASE=xenial
+
+FROM ppc64le/ubuntu:${UBUNTU_RELEASE}
+
+ARG UBUNTU_RELEASE=xenial
 
 WORKDIR /root
 
-ARG DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN [ -n "$HTTP_PROXY" ] && echo Acquire::http::proxy '"'$HTTP_PROXY'";' >> /etc/apt/apt.conf.d/http_proxy || :
+RUN [ -n "$HTTPS_PROXY" ] && echo Acquire::https::proxy '"'$HTTPS_PROXY'";' >> /etc/apt/apt.conf.d/https_proxy || :
+RUN [ -n "$FTP_PROXY" ] && echo Acquire::ftp::proxy '"'$FTP_PROXY'";' >> /etc/apt/apt.conf.d/ftp_proxy || :
 
 # Configure apt to nicely install packages
 RUN apt-get update \
     && apt-get install -y apt-utils \
-    && apt-get install -y autoconf automake bison byacc ccache cscope ctags curl flex \
+        autoconf automake bison byacc ccache cscope ctags curl flex \
         elfutils libtool libstdc++-4.8-dev m4 make man-db \
     && apt-get clean
 
-ENV AT_VERSION 10.0
+ARG AT_VERSION=10.0
 
-RUN curl -O ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key \
-    && apt-key add 6976a827.gpg.key \
-    && rm -f 6976a827.gpg.key \
-    && echo "deb ftp://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu trusty at${AT_VERSION}" >> /etc/apt/sources.list \
+ENV http_proxy $HTTP_PROXY
+
+RUN curl http://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu/dists/trusty/6976a827.gpg.key | apt-key add - \
+    && echo "deb http://ftp.unicamp.br/pub/linuxpatch/toolchain/at/ubuntu ${UBUNTU_RELEASE} at${AT_VERSION}" >> /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y advance-toolchain-at${AT_VERSION}-runtime advance-toolchain-at${AT_VERSION}-devel \
         advance-toolchain-at${AT_VERSION}-perf advance-toolchain-at${AT_VERSION}-mcore-libs


### PR DESCRIPTION

Just a few ideas more than a finished PR (that I'll probably never get around to) - multi AT version and account for a multiple ubuntu versions.

* enable proxy support too
* use http URLs because they proxy cache easier on what is quite a slow server

<pre>
docker build --no-cache  --build-arg AT_VERSION=11.0 --build-arg FTP_PROXY=$ftp_proxy --build-arg HTTP_PROXY=$http_proxy  --build-arg HTTPS_PROXY=$https_proxy -f Dockerfile-devel_ppc64le .
...
Step 14/14 : CMD ["/bin/bash"]
 ---> Running in 501b95357579
Removing intermediate container 501b95357579
 ---> e43bba547f72
Successfully built e43bba547f72
$ docker run e43bba547f72 gcc --version
gcc (GCC) 7.3.1 20180207 (Advance-Toolchain-at11.0) [ibm/gcc-7-branch revision 257393]
</pre>


<pre> 
$ docker build --build-arg UBUNTU_RELEASE=trusty --build-arg AT_VERSION=10.0 --build-arg FTP_PROXY=http://proxy:3128/ --build-arg HTTP_PROXY=http://proxy:3128/ --build-arg HTTPS_PROXY=http://proxy:3128/ -f Dockerfile-devel_ppc64le .
---> 3466bd1148a9
Successfully built 3466bd1148a9
$ docker run -ti 3466bd1148a9 gcc --version
gcc (GCC) 6.4.1 20170720 (Advance-Toolchain-at10.0) IBM AT 10 branch, based on subversion id 250395.
</pre>

Note1: UBUNTU_RELEASE appears as a duplicate argument - however its needed twice before and after the FROM line otherwise it won't be available in the AT URL.
Note2: proxy variable don't need to be ARGS, they are built in https://docs.docker.com/engine/reference/builder/#predefined-args
